### PR TITLE
Use configureAwait to allow use in non async paths

### DIFF
--- a/FireSharp.WebApp/Controllers/HomeController.cs
+++ b/FireSharp.WebApp/Controllers/HomeController.cs
@@ -29,5 +29,26 @@ namespace FireSharp.WebApp.Controllers
 
             return RedirectToAction("Index");
         }
+
+        public ActionResult CallFirebaseSync()
+        {
+            _client.Push("chat/", new 
+            {
+                name = "someone",
+                text = "Hello from backend :" + DateTime.Now.ToString("f")
+            });
+
+            return Content("hello");
+        }
+
+        public ActionResult CallFirebaseSync2()
+        {
+            _client.PushAsync("chat/", new {
+                name = "someone",
+                text = "Hello from backend :" + DateTime.Now.ToString("f")
+            }).Wait();
+
+            return Content("hello");
+        }
     }
 }

--- a/FireSharp/FirebaseClient.cs
+++ b/FireSharp/FirebaseClient.cs
@@ -42,7 +42,7 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = _requestManager.Get(path);
+                HttpResponseMessage response = _requestManager.GetAsync(path).Result;
                 string content = response.Content.ReadAsStringAsync().Result;
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new FirebaseResponse(content, response.StatusCode);
@@ -57,7 +57,7 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = _requestManager.Put(path, data);
+                HttpResponseMessage response = _requestManager.PutAsync(path, data).Result;
                 string content = response.Content.ReadAsStringAsync().Result;
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new SetResponse(content, response.StatusCode);
@@ -72,7 +72,7 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = _requestManager.Post(path, data);
+                HttpResponseMessage response = _requestManager.PostAsync(path, data).Result;
                 string content = response.Content.ReadAsStringAsync().Result;
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new PushResponse(content, response.StatusCode);
@@ -87,7 +87,7 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = _requestManager.Delete(path);
+                HttpResponseMessage response = _requestManager.DeleteAsync(path).Result;
                 string content = response.Content.ReadAsStringAsync().Result;
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new DeleteResponse(content, response.StatusCode);
@@ -102,7 +102,7 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = _requestManager.Patch(path, data);
+                HttpResponseMessage response = _requestManager.PatchAsync(path, data).Result;
                 string content = response.Content.ReadAsStringAsync().Result;
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new FirebaseResponse(content, response.StatusCode);
@@ -117,8 +117,8 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = await _requestManager.GetAsync(path);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await _requestManager.GetAsync(path).ConfigureAwait(false);
+                string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new FirebaseResponse(content, response.StatusCode);
             }
@@ -132,8 +132,8 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = await _requestManager.PutAsync(path, data);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await _requestManager.PutAsync(path, data).ConfigureAwait(false);
+                string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new SetResponse(content, response.StatusCode);
             }
@@ -147,8 +147,8 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = await _requestManager.PostAsync(path, data);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await _requestManager.PostAsync(path, data).ConfigureAwait(false);
+                string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new PushResponse(content, response.StatusCode);
             }
@@ -162,8 +162,8 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = await _requestManager.DeleteAsync(path);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await _requestManager.DeleteAsync(path).ConfigureAwait(false);
+                string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new DeleteResponse(content, response.StatusCode);
             }
@@ -177,8 +177,8 @@ namespace FireSharp
         {
             try
             {
-                HttpResponseMessage response = await _requestManager.PatchAsync(path, data);
-                string content = await response.Content.ReadAsStringAsync();
+                HttpResponseMessage response = await _requestManager.PatchAsync(path, data).ConfigureAwait(false);
+                string content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                 HandleIfErrorResponse(response.StatusCode, content);
                 return new FirebaseResponse(content, response.StatusCode);
             }
@@ -193,18 +193,18 @@ namespace FireSharp
             ValueChangedEventHandler changed = null,
             ValueRemovedEventHandler removed = null)
         {
-            return new EventStreamResponse(await _requestManager.ListenAsync(path), added, changed, removed);
+            return new EventStreamResponse(await _requestManager.ListenAsync(path).ConfigureAwait(false), added, changed, removed);
         }
 
         public async Task<EventRootResponse<T>> OnChangeGetAsync<T>(string path, ValueRootAddedEventHandler<T> added = null)
         {
-            return new EventRootResponse<T>(await _requestManager.ListenAsync(path), added, _requestManager, path);
+            return new EventRootResponse<T>(await _requestManager.ListenAsync(path).ConfigureAwait(false), added, _requestManager, path);
         }
 
         public async Task<EventStreamResponse> OnAsync(string path, ValueAddedEventHandler added = null, ValueChangedEventHandler changed = null,
             ValueRemovedEventHandler removed = null)
         {
-            return new EventStreamResponse(await _requestManager.ListenAsync(path), added, changed, removed);
+            return new EventStreamResponse(await _requestManager.ListenAsync(path).ConfigureAwait(false), added, changed, removed);
         }
 
         private void HandleIfErrorResponse(HttpStatusCode statusCode, string content, Action<HttpStatusCode, string> errorHandler = null)

--- a/FireSharp/Interfaces/IRequestManager.cs
+++ b/FireSharp/Interfaces/IRequestManager.cs
@@ -12,11 +12,5 @@ namespace FireSharp.Interfaces
         Task<HttpResponseMessage> PostAsync<T>(string path, T data);
         Task<HttpResponseMessage> DeleteAsync(string path);
         Task<HttpResponseMessage> PatchAsync<T>(string path, T data);
-        HttpResponseMessage Listen(string path);
-        HttpResponseMessage Get(string path);
-        HttpResponseMessage Put<T>(string path, T data);
-        HttpResponseMessage Post<T>(string path, T data);
-        HttpResponseMessage Delete(string path);
-        HttpResponseMessage Patch<T>(string path, T data);
     }
 }

--- a/FireSharp/RequestManager.cs
+++ b/FireSharp/RequestManager.cs
@@ -35,66 +35,29 @@ namespace FireSharp
         {
         }
 
-        public async Task<HttpResponseMessage> GetAsync(string path)
+        public Task<HttpResponseMessage> GetAsync(string path)
         {
-            return await ProcessRequestAsync(HttpMethod.Get, path, null);
+            return ProcessRequestAsync(HttpMethod.Get, path, null);
         }
 
-        public async Task<HttpResponseMessage> PutAsync<T>(string path, T data)
+        public Task<HttpResponseMessage> PutAsync<T>(string path, T data)
         {
-            return await ProcessRequestAsync(HttpMethod.Put, path, data);
+            return ProcessRequestAsync(HttpMethod.Put, path, data);
         }
 
-        public async Task<HttpResponseMessage> PostAsync<T>(string path, T data)
+        public Task<HttpResponseMessage> PostAsync<T>(string path, T data)
         {
-            return await ProcessRequestAsync(HttpMethod.Post, path, data);
+            return ProcessRequestAsync(HttpMethod.Post, path, data);
         }
 
-        public async Task<HttpResponseMessage> DeleteAsync(string path)
+        public Task<HttpResponseMessage> DeleteAsync(string path)
         {
-            return await ProcessRequestAsync(HttpMethod.Delete, path, null);
+            return ProcessRequestAsync(HttpMethod.Delete, path, null);
         }
 
-        public async Task<HttpResponseMessage> PatchAsync<T>(string path, T data)
+        public Task<HttpResponseMessage> PatchAsync<T>(string path, T data)
         {
-            return await ProcessRequestAsync(new HttpMethod("PATCH"), path, data);
-        }
-
-
-        public HttpResponseMessage Get(string path)
-        {
-            return ProcessRequest(HttpMethod.Get, path, null);
-        }
-
-        public HttpResponseMessage Put<T>(string path, T data)
-        {
-            return ProcessRequest(HttpMethod.Put, path, data);
-        }
-
-        public HttpResponseMessage Post<T>(string path, T data)
-        {
-            return ProcessRequest(HttpMethod.Post, path, data);
-        }
-
-        public HttpResponseMessage Delete(string path)
-        {
-            return ProcessRequest(HttpMethod.Delete, path, null);
-        }
-
-        public HttpResponseMessage Patch<T>(string path, T data)
-        {
-            return ProcessRequest(new HttpMethod("PATCH"), path, data);
-        }
-
-        public HttpResponseMessage Listen(string path)
-        {
-            HttpRequestMessage request;
-            var client = PrepareEventStreamRequest(path, out request);
-
-            var response = client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead).Result;
-            response.EnsureSuccessStatusCode();
-
-            return response;
+            return ProcessRequestAsync(new HttpMethod("PATCH"), path, data);
         }
 
         public async Task<HttpResponseMessage> ListenAsync(string path)
@@ -108,28 +71,13 @@ namespace FireSharp
             return response;
         }
 
-        private async Task<HttpResponseMessage> ProcessRequestAsync(HttpMethod method, string path, object payload, HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
+        private Task<HttpResponseMessage> ProcessRequestAsync(HttpMethod method, string path, object payload, HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
         {
             try
             {
                 var request = PrepareRequest(method, path, payload);
 
-                return await GetClient().SendAsync(request, httpCompletionOption);
-            }
-            catch (Exception ex)
-            {
-                throw new FirebaseException(
-                    string.Format("An error occured while execute request. Path : {0} , Method : {1}", path, method), ex);
-            }
-        }
-
-        private HttpResponseMessage ProcessRequest(HttpMethod method, string path, object payload, HttpCompletionOption httpCompletionOption = HttpCompletionOption.ResponseContentRead)
-        {
-            try
-            {
-                var request = PrepareRequest(method, path, payload);
-
-                return GetClient().SendAsync(request, httpCompletionOption).Result;
+                return GetClient().SendAsync(request, httpCompletionOption);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
Also simplified IRequestManager to only be async and removed unnecessary
async/await calls.

When writing a library, it is best practice to use ConfigureAwait(false) when awaiting. This can prevent deadlocks when running under a synchronization context such as provided by ASP.net. See here for more background: http://stackoverflow.com/questions/13489065/best-practice-to-call-configureawait-for-all-server-side-code

I added 2 new actions in the webapp which illustrate the problem. Hitting /home/callfirebasesync2 will result in a deadlock in the old code, but with this PR, it works exactly like the /home/callfirebase method.

I also removed the non-async methods in IRequestManager, since with these changes they are identical to the sync versions. I'd like to simply that interface even further. I see little value in having Push/Get/Delete/... as separate methods. IRequestManager could simply be 
```
Task<HttpResponseMessage> ProcessRequestAsync(HttpMethod method, string path, object payload);
```
If you agree, I'm happy to submit a PR with those changes as well. 
