### PR TITLE
Automatically handles BasePath which does or does not end with slash.

### DIFF
--- a/FireSharp/RequestManager.cs
+++ b/FireSharp/RequestManager.cs
@@ -23,7 +23,8 @@ namespace FireSharp
         {
             var client = handler == null ? new HttpClient() : new HttpClient(handler, true);
 
-            client.BaseAddress = new Uri(_config.BasePath);
+            var basePath = _config.BasePath.EndsWith("/") ? _config.BasePath : _config.BasePath + "/";
+            client.BaseAddress = new Uri(basePath);
 
             if (_config.RequestTimeout.HasValue)
             {
@@ -95,7 +96,8 @@ namespace FireSharp
                 ? string.Format("{0}.json?auth={1}", path, _config.AuthSecret)
                 : string.Format("{0}.json", path);
 
-            var url = string.Format("{0}{1}", _config.BasePath, authToken);
+            var basePath = _config.BasePath.EndsWith("/") ? _config.BasePath : _config.BasePath + "/";
+            var url = string.Format("{0}{1}", basePath, authToken);
 
             return new Uri(url);
         }


### PR DESCRIPTION
Since FireSharp automatically appends a file to the URI, we know a slash is supposed to be in between, but users aren't necessarily used to ending just domain names with a trailing slash and shouldn't need to here.  This makes it flexibly take the path either way.  Also adds a test for utilizing two clients at the same time; while one generally shouldn't need to, it should work just the same.