### PR TITLE
QueryBuilder: Added support to long type for StartAt and EndAt

### DIFF
--- a/FireSharp.Tests/FirebaseQueryTests.cs
+++ b/FireSharp.Tests/FirebaseQueryTests.cs
@@ -23,10 +23,26 @@ namespace FireSharp.Tests
         [Test]
         public void EndAtQueryTest()
         {
-            QueryBuilder queryBuilder = QueryBuilder.New().StartAt("a");
+            QueryBuilder queryBuilder = QueryBuilder.New().EndAt("a");
             var queryString = queryBuilder.ToQueryString();
-            queryString.ShouldBeEquivalentTo("startAt=\"a\"");
+            queryString.ShouldBeEquivalentTo("endAt=\"a\"");
         }
+
+        [Test]
+        public void StartAtNumberQueryTest()
+        {
+            QueryBuilder queryBuilder = QueryBuilder.New().StartAt(1472342400);
+            var queryString = queryBuilder.ToQueryString();
+            queryString.ShouldBeEquivalentTo("startAt=1472342400");
+        }
+        [Test]
+        public void EndAtNumberQueryTest()
+        {
+            QueryBuilder queryBuilder = QueryBuilder.New().StartAt(1472342400);
+            var queryString = queryBuilder.ToQueryString();
+            queryString.ShouldBeEquivalentTo("endAt=1472342400");
+        }
+
         [Test]
         public void OrderByQueryTest()
         {

--- a/FireSharp/QueryBuilder.cs
+++ b/FireSharp/QueryBuilder.cs
@@ -33,7 +33,17 @@ namespace FireSharp
             return AddToQueryDictionary(startAtParam, value);
         }
 
+        public QueryBuilder StartAt(long value)
+        {
+            return AddToQueryDictionary(startAtParam, value);
+        }
+
         public QueryBuilder EndAt(string value)
+        {
+            return AddToQueryDictionary(endAtParam, value);
+        }
+
+        public QueryBuilder EndAt(long value)
         {
             return AddToQueryDictionary(endAtParam, value);
         }
@@ -76,6 +86,12 @@ namespace FireSharp
                 _query.Remove(startAtParam);
             }
 
+            return this;
+        }
+
+        private QueryBuilder AddToQueryDictionary(string parameterName, long value)
+        {
+            _query.Add(parameterName, value);
             return this;
         }
 


### PR DESCRIPTION
Use case: using timestamp (long) type in firebase for filtering data.