### PR TITLE
Awaiting the inner task instead of the outer task

### DIFF
--- a/FireSharp/Response/EventRootResponse.cs
+++ b/FireSharp/Response/EventRootResponse.cs
@@ -36,7 +36,7 @@ namespace FireSharp.Response
 
         private async Task ReadLoop(HttpResponseMessage httpResponse, CancellationToken token)
         {
-            await Task.Factory.StartNew(async () =>
+            await Task.Run(async () =>
             {
                 using (httpResponse)
                 using (var content = await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false))

--- a/FireSharp/Response/EventStreamResponse.cs
+++ b/FireSharp/Response/EventStreamResponse.cs
@@ -52,7 +52,7 @@ namespace FireSharp.Response
 
         private async Task ReadLoop(HttpResponseMessage httpResponse, CancellationToken token)
         {
-            await Task.Factory.StartNew(async () =>
+            await Task.Run(async () =>
             {
                 using (httpResponse)
                 using (var content = await httpResponse.Content.ReadAsStreamAsync())


### PR DESCRIPTION
Task.Factory.StartNew returns a nested task (Task<Task>). Awaiting a nested task is dangerous so we should always unwrap the nested task (with Unwrap() or using Task.Run) and await the inner task.

