### PR TITLE
Awaiting the inner task instead of the outer task

### DIFF
--- a/FireSharp/Response/EventRootResponse.cs
+++ b/FireSharp/Response/EventRootResponse.cs
@@ -77,7 +77,7 @@ namespace FireSharp.Response
                         eventName = null;
                     }
                 }
-            }, token, TaskCreationOptions.LongRunning, TaskScheduler.Default);
+            }, token, TaskCreationOptions.LongRunning, TaskScheduler.Default).Unwrap();
         }
 
         public void Cancel()

--- a/FireSharp/Response/EventStreamResponse.cs
+++ b/FireSharp/Response/EventStreamResponse.cs
@@ -89,7 +89,7 @@ namespace FireSharp.Response
                         eventName = null;
                     }
                 }
-            }, TaskCreationOptions.LongRunning);
+            }, TaskCreationOptions.LongRunning).Unwrap();
         }
 
 


### PR DESCRIPTION
Task.Factory.StartNew returns a nested task (Task<Task>). Awaiting a nested task is dangerous so we should always unwrap the nested task (with Unwrap() or using Task.Run) and await the inner task.
