### PR TITLE
Fixed build failure issue. EndOfObject should have been EndObject.

### DIFF
--- a/FireSharp/EventStreaming/TemporaryCache.cs
+++ b/FireSharp/EventStreaming/TemporaryCache.cs
@@ -111,7 +111,7 @@ namespace FireSharp.EventStreaming
                     case JsonToken.Null:
                         DeleteChild(root);
                         return;
-                    case JsonToken.EndOfObject: break;
+                    case JsonToken.EndObject: break;
                 }
             }
         }


### PR DESCRIPTION
I looked in different branches of Newtonsoft.Json to look if it is named EndOfObject anywhere but could not find it.