### PR TITLE
Do not modify date strings on Update

### DIFF
--- a/FireSharp.Serialization.JsonNet/JsonSerializerWrapper.cs
+++ b/FireSharp.Serialization.JsonNet/JsonSerializerWrapper.cs
@@ -5,14 +5,16 @@ namespace FireSharp.Serialization.JsonNet
 {
     internal class JsonSerializerWrapper : ISerializer
     {
+        private static readonly JsonSerializerSettings _settings = new JsonSerializerSettings { DateParseHandling = DateParseHandling.None };
+
         public T Deserialize<T>(string json)
         {
-            return JsonConvert.DeserializeObject<T>(json);
+            return JsonConvert.DeserializeObject<T>(json, _settings);
         }
 
         public string Serialize<T>(T value)
         {
-            return JsonConvert.SerializeObject(value);
+            return JsonConvert.SerializeObject(value, _settings);
         }
     }
 }

--- a/FireSharp/Response/EventStreamResponse.cs
+++ b/FireSharp/Response/EventStreamResponse.cs
@@ -106,6 +106,7 @@ namespace FireSharp.Response
                 case "patch":
                     using (var reader = new JsonTextReader(new StringReader(p)))
                     {
+                        reader.DateParseHandling = DateParseHandling.None;
                         ReadToNamedPropertyValue(reader, "path");
                         reader.Read();
                         var path = reader.Value.ToString();


### PR DESCRIPTION
If a date property is updated, then the OnAsync changed delegate would get the date value automatically changed in to a different string representation of the date, e.g. `2016-05-05T11:42:01.013Z` would get changed in to `05/05/2016 11:42.01`. This is because Json.Net automatically attempts to deserialize DateTime strings in to DateTime objects, then when cast back to a string it uses the default `DateTime.ToString()`. 

This behaviour can be disabled using `DateParseHandling.None`.

See http://www.newtonsoft.com/json/help/html/T_Newtonsoft_Json_DateParseHandling.htm