### PR TITLE
Allow updates (with POST/PUT/DELETE) to follow redirects

### DIFF
--- a/FireSharp/AutoRedirectHttpClientHandler.cs
+++ b/FireSharp/AutoRedirectHttpClientHandler.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace FireSharp 
+{
+    internal class AutoRedirectHttpClientHandler : DelegatingHandler 
+    {
+        private int _maximumAutomaticRedirections;
+
+        public int MaximumAutomaticRedirections 
+        {
+          get { return _maximumAutomaticRedirections; }
+          set 
+          {
+              if (value < 1) 
+              {
+                throw new ArgumentException("The specified value must be greater than 0.");
+              }
+
+              _maximumAutomaticRedirections = value;
+          }
+        }
+
+        public AutoRedirectHttpClientHandler()
+        {
+            var handler = new HttpClientHandler { AllowAutoRedirect = false };
+            InnerHandler = handler;
+            MaximumAutomaticRedirections = handler.MaxAutomaticRedirections;
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) 
+        {
+            var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+            if (!IsRedirect(response)) 
+            {
+                return response;
+            }
+
+            var redirectCount = 0;
+
+            while (IsRedirect(response)) 
+            {
+                redirectCount++;
+
+                if (redirectCount > MaximumAutomaticRedirections) 
+                {
+                   throw new WebException("Too many automatic redirections were attempted.");
+                }
+
+                request.RequestUri = response.Headers.Location;
+                response = await SendAsync(request, cancellationToken).ConfigureAwait(false);
+            }
+
+            return response;
+        }
+
+        private static bool IsRedirect(HttpResponseMessage response) 
+        {
+            switch (response.StatusCode) 
+            {
+                case HttpStatusCode.MovedPermanently:
+                case HttpStatusCode.Redirect:
+                case HttpStatusCode.RedirectMethod:
+                case HttpStatusCode.RedirectKeepVerb:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+    }
+}

--- a/FireSharp/FireSharp.csproj
+++ b/FireSharp/FireSharp.csproj
@@ -72,6 +72,7 @@
     <None Include="app.config" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AutoRedirectHttpClientHandler.cs" />
     <Compile Include="Config\FirebaseConfig.cs" />
     <Compile Include="EventStreaming\SimpleCacheItem.cs" />
     <Compile Include="EventStreaming\Delegates.cs" />

--- a/FireSharp/RequestManager.cs
+++ b/FireSharp/RequestManager.cs
@@ -20,7 +20,7 @@ namespace FireSharp
 
             _config = config;
 
-            _httpClient = new HttpClient(new HttpClientHandler { AllowAutoRedirect = true });
+            _httpClient = new HttpClient(new AutoRedirectHttpClientHandler());
 
             var basePath = _config.BasePath.EndsWith("/") ? _config.BasePath : _config.BasePath + "/";
             _httpClient.BaseAddress = new Uri(basePath);


### PR DESCRIPTION
When a POST/PUT/DELETE occurs, .NET HttpClient does not automatically follow a redirect (`301/302/303/307`) to post the data elsewhere.

The Nest API sends a `307` on updates and therefore needs to follow the redirect in order to work (see #53).

