### PR TITLE
Added support for Access Token authentication

### DIFF
--- a/FireSharp.Core/Config/FirebaseConfig.cs
+++ b/FireSharp.Core/Config/FirebaseConfig.cs
@@ -22,9 +22,10 @@ namespace FireSharp.Core.Config
         }
 
         public string Host { get; set; }
-        public string AuthSecret { get; set; }
+		public string AuthSecret { get; set; }
+		public string AccessToken { get; set; }
 
-        public TimeSpan? RequestTimeout { get; set; }
+		public TimeSpan? RequestTimeout { get; set; }
 
         public ISerializer Serializer { get; set; }
     }

--- a/FireSharp.Core/Config/FirebaseConfig.cs
+++ b/FireSharp.Core/Config/FirebaseConfig.cs
@@ -22,10 +22,10 @@ namespace FireSharp.Core.Config
         }
 
         public string Host { get; set; }
-		public string AuthSecret { get; set; }
-		public string AccessToken { get; set; }
+        public string AuthSecret { get; set; }
+        public string AccessToken { get; set; }
 
-		public TimeSpan? RequestTimeout { get; set; }
+        public TimeSpan? RequestTimeout { get; set; }
 
         public ISerializer Serializer { get; set; }
     }

--- a/FireSharp.Core/Interfaces/IFirebaseConfig.cs
+++ b/FireSharp.Core/Interfaces/IFirebaseConfig.cs
@@ -7,7 +7,8 @@ namespace FireSharp.Core.Interfaces
         string BasePath { get; set; }
         string Host { get; set; }
         string AuthSecret { get; set; }
-        TimeSpan? RequestTimeout { get; set; }
+		string AccessToken { get; set; }
+		TimeSpan? RequestTimeout { get; set; }
         ISerializer Serializer { get; set; }
     }
 }

--- a/FireSharp.Core/Interfaces/IFirebaseConfig.cs
+++ b/FireSharp.Core/Interfaces/IFirebaseConfig.cs
@@ -7,8 +7,8 @@ namespace FireSharp.Core.Interfaces
         string BasePath { get; set; }
         string Host { get; set; }
         string AuthSecret { get; set; }
-		string AccessToken { get; set; }
-		TimeSpan? RequestTimeout { get; set; }
+        string AccessToken { get; set; }
+        TimeSpan? RequestTimeout { get; set; }
         ISerializer Serializer { get; set; }
     }
 }

--- a/FireSharp.Core/RequestManager.cs
+++ b/FireSharp.Core/RequestManager.cs
@@ -108,11 +108,11 @@ namespace FireSharp.Core
             request = new HttpRequestMessage(HttpMethod.Get, uri);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
 
-			if (!string.IsNullOrEmpty(_config.AccessToken)) {
-				request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AccessToken);
-			}
+            if (!string.IsNullOrEmpty(_config.AccessToken)) {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AccessToken);
+            }
 
-			return client;
+            return client;
         }
 
         private HttpRequestMessage PrepareRequest(HttpMethod method, Uri uri, object payload)
@@ -124,9 +124,9 @@ namespace FireSharp.Core
                 request.Content = new StringContent(payload as string ?? _config.Serializer.Serialize(payload));
             }
 
-			if (!string.IsNullOrEmpty(_config.AccessToken)) {
-				request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AccessToken);
-			}
+            if (!string.IsNullOrEmpty(_config.AccessToken)) {
+                request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AccessToken);
+            }
 
             return request;
         }

--- a/FireSharp.Core/RequestManager.cs
+++ b/FireSharp.Core/RequestManager.cs
@@ -108,7 +108,11 @@ namespace FireSharp.Core
             request = new HttpRequestMessage(HttpMethod.Get, uri);
             request.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
 
-            return client;
+			if (!string.IsNullOrEmpty(_config.AccessToken)) {
+				request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AccessToken);
+			}
+
+			return client;
         }
 
         private HttpRequestMessage PrepareRequest(HttpMethod method, Uri uri, object payload)
@@ -119,6 +123,10 @@ namespace FireSharp.Core
             {
                 request.Content = new StringContent(payload as string ?? _config.Serializer.Serialize(payload));
             }
+
+			if (!string.IsNullOrEmpty(_config.AccessToken)) {
+				request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _config.AccessToken);
+			}
 
             return request;
         }


### PR DESCRIPTION
Access Token authentication is the new recommended authentication mechanism as database secrets are deprecated (https://firebase.google.com/docs/database/rest/auth)

#106 