### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Console.WriteLine(response.StatusCode);
 ```
 #### Listen **Streaming from the REST API**
 ```csharp
-EventStreamResponse response = await _client.OnAsync("chat", (sender, args) => {
+EventStreamResponse response = await _client.OnAsync("chat", (sender, args, context) => {
        System.Console.WriteLine(args.Data);
 });
 


### PR DESCRIPTION
The arguments for the Streaming REST API takes 3 arguments now and not 2 so changed it suit so newbies wouldn't be confused when they are getting the  does not take 2 declare arguments error